### PR TITLE
Fix: [AEA-0000] - change esbuild to bundle dependendencies

### DIFF
--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -135,6 +135,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 

--- a/SAMtemplates/sandbox_template.yaml
+++ b/SAMtemplates/sandbox_template.yaml
@@ -79,7 +79,6 @@ Conditions:
   ShouldUseSplunk: !Equals [true, !Ref EnableSplunk]
 
 Resources:
-
   # sandbox lambda
   SandboxResources:
     Type: AWS::Serverless::Application
@@ -113,6 +112,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: sandbox/tsconfig.json
+        packages: bundle
         EntryPoints:
           - sandbox/src/sandbox.ts
 
@@ -153,6 +153,7 @@ Resources:
         Target: "es2020"
         Sourcemap: true
         tsconfig: statusLambda/tsconfig.json
+        packages: bundle
         EntryPoints:
           - statusLambda/src/statusLambda.ts
 


### PR DESCRIPTION
## Summary

- Routine Change

### Details

- change esbuild to bundle dependencies following default behavior in esbuild 0.22 - https://github.com/evanw/esbuild/releases/tag/v0.22.0