### PR TITLE
Build: [AEA-4149] - Bump nodejs version to 20.X

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-nodejs 18.16.0
+nodejs 20.17.0
 python 3.8.15
 poetry 1.6.1
 shellcheck 0.9.0

--- a/SAMtemplates/main_template.yaml
+++ b/SAMtemplates/main_template.yaml
@@ -10,7 +10,7 @@ Globals:
     MemorySize: 256
     Architectures:
       - x86_64
-    Runtime: nodejs18.x
+    Runtime: nodejs20.x
     Environment:
       Variables:
         TargetSpineServer: !Ref TargetSpineServer

--- a/SAMtemplates/sandbox_template.yaml
+++ b/SAMtemplates/sandbox_template.yaml
@@ -10,7 +10,7 @@ Globals:
     MemorySize: 256
     Architectures:
       - x86_64
-    Runtime: nodejs18.x
+    Runtime: nodejs20.x
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change
- 
### Details

Bumping Node-JS to version 20.x. 

#### Acceptance Criteria

- local dev container runs node 20
- lambdas deployed use node 20
- all unit tests pass
