### PR TITLE
Fix: [AEA-0000]- add missing gh pages checkout to workflow

### DIFF
--- a/.github/workflows/cdk_release_code.yml
+++ b/.github/workflows/cdk_release_code.yml
@@ -185,6 +185,13 @@ jobs:
           name: ${{ inputs.APIGEE_ENVIRONMENT }}-specs
           path: |
             ./.build/packages/specification/dist/eps-clinical-prescription-tracker-api.resolved.json
+      
+      - name: Checkout gh-pages
+        if: ${{ !startsWith(inputs.STACK_NAME, 'cpt-pr-') }}
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
 
       - name: Update release tag in github pages
         if: ${{ !startsWith(inputs.STACK_NAME, 'cpt-pr-') }}


### PR DESCRIPTION
## Summary
- Routine Change

### Details
- Adds missing checkout Github pages step for cdk_release_code workflow